### PR TITLE
🐛 Cannot run\discover tests when there are space characters in the path

### DIFF
--- a/sample/Tests/Test With Space.Tests.ps1
+++ b/sample/Tests/Test With Space.Tests.ps1
@@ -1,0 +1,3 @@
+Describe 'Test with Space' {
+	It 'Loads' {}
+}

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -260,7 +260,12 @@ export class PesterTestController implements Disposable {
 
 		scriptArgs.push('-PipeName')
 		scriptArgs.push(this.returnServer.name)
-		scriptArgs.push(...testsToRun)
+		// Quotes are required when passing to integrated terminal if the test path has spaces
+		scriptArgs.push(
+			...testsToRun.map(testFilePath => {
+				return `'${testFilePath}'`
+			})
+		)
 
 		if (!this.powerShellExtensionClient) {
 			this.powerShellExtensionClient = await PowerShellExtensionClient.create(


### PR DESCRIPTION
Fixes #26