### PR TITLE
🐛 Normalize all Windows paths to uppercase and throw syntax errors on bad test files

### DIFF
--- a/Scripts/PesterInterface.ps1
+++ b/Scripts/PesterInterface.ps1
@@ -3,23 +3,22 @@ using namespace System.Collections
 using namespace System.Collections.Generic
 using namespace Pester
 
-
 [CmdletBinding()]
 param(
-	#Path(s) to search for tests. Paths can also contain line numbers (e.g. /path/to/file:25)
-	[Parameter(ValueFromRemainingArguments)][String[]]$Path = $PWD,
-	#Only return "It" Test Results and not the resulting hierarcy
-	[Switch]$TestsOnly,
-	#Only return the test information, don't actually run them. Also returns minimal output
-	[Switch]$Discovery,
-	#Only load the functions but don't execute anything. Used for testing.
-	[Parameter(DontShow)][Switch]$LoadFunctionsOnly,
-	#If specified, emit the output objects as a flattened json to the specified named pipe handle. Used for IPC to the extension
-	[String]$PipeName,
-	#If specified just emit the json to stdout instead of the pipe
-	[Switch]$PassThru,
-	#The verbosity to pass to the system
-	[String]$Verbosity
+  #Path(s) to search for tests. Paths can also contain line numbers (e.g. /path/to/file:25)
+  [Parameter(ValueFromRemainingArguments)][String[]]$Path = $PWD,
+  #Only return "It" Test Results and not the resulting hierarcy
+  [Switch]$TestsOnly,
+  #Only return the test information, don't actually run them. Also returns minimal output
+  [Switch]$Discovery,
+  #Only load the functions but don't execute anything. Used for testing.
+  [Parameter(DontShow)][Switch]$LoadFunctionsOnly,
+  #If specified, emit the output objects as a flattened json to the specified named pipe handle. Used for IPC to the extension
+  [String]$PipeName,
+  #If specified just emit the json to stdout instead of the pipe
+  [Switch]$PassThru,
+  #The verbosity to pass to the system
+  [String]$Verbosity
 )
 
 $VerbosePreference = 'SilentlyContinue'
@@ -29,295 +28,308 @@ $DebugPreference = 'SilentlyContinue'
 #region Functions
 # Maps pester result status to vscode result status
 enum ResultStatus {
-	Unset
-	Queued
-	Running
-	Passed
-	Failed
-	Skipped
-	Errored
-	NotRun #Pester Specific, this should be ignored
+  Unset
+  Queued
+  Running
+  Passed
+  Failed
+  Skipped
+  Errored
+  NotRun #Pester Specific, this should be ignored
 }
 
 function Merge-TestData () {
-	#Produce a unified test Data object from this object and its parents
-	#Merge the local data and block data. Local data takes precedence.
-	#Used in Test ID creation
-	[CmdletBinding()]
-	param(
-		[Parameter(Mandatory, ValueFromPipeline)]
-		[ValidateScript( {
-				[bool]($_.PSTypeNames -match '(Pester\.)?(Test|Block)$')
-			})]$Test
-	)
-	#TODO: Nested Describe/Context Foreach?
-	#TODO: Edge cases
-	#Non-String Object
-	#Non-String Hashtable
-	#Other dictionaries
-	#Nested Hashtables
-	#Fancy TestCases, maybe just iterate them as TestCaseN or exclude
+  #Produce a unified test Data object from this object and its parents
+  #Merge the local data and block data. Local data takes precedence.
+  #Used in Test ID creation
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [ValidateScript( {
+        [bool]($_.PSTypeNames -match '(Pester\.)?(Test|Block)$')
+      })]$Test
+  )
+  #TODO: Nested Describe/Context Foreach?
+  #TODO: Edge cases
+  #Non-String Object
+  #Non-String Hashtable
+  #Other dictionaries
+  #Nested Hashtables
+  #Fancy TestCases, maybe just iterate them as TestCaseN or exclude
 
 
-	#If data is not iDictionary array, we will store it as _ to standardize this is a bit
-	$Data = [SortedDictionary[string, object]]::new()
+  #If data is not iDictionary array, we will store it as _ to standardize this is a bit
+  $Data = [SortedDictionary[string, object]]::new()
 
-	#Block and parent are interchangeable
-	if ($Test -is [Pester.Test]) {
-		Add-Member -InputObject $Test -NotePropertyName 'Parent' -NotePropertyValue $Test.Block -Force
-	}
+  #Block and parent are interchangeable
+  if ($Test -is [Pester.Test]) {
+    Add-Member -InputObject $Test -NotePropertyName 'Parent' -NotePropertyValue $Test.Block -Force
+  }
 
-	#This will merge the block data, with the lowest level data taking precedence
-	#TODO: Use a stack to iterate this
-	$DataSources = ($Test.Parent.Parent.Data, $Test.Parent.Data, $Test.Data).where{ $PSItem }
-	foreach ($DataItem in $DataSources) {
-		if ($DataItem) {
-			if ($DataItem -is [IDictionary]) {
-				$DataItem.GetEnumerator().foreach{
-					$Data.$($PSItem.Name) = $PSItem.Value
-				}
-			} else {
-				#Save to the "_" key if it was an array input since that's what Pester uses for substitution
-				$Data._ = $DataItem
-			}
-		}
-	}
-	return $Data
+  #This will merge the block data, with the lowest level data taking precedence
+  #TODO: Use a stack to iterate this
+  $DataSources = ($Test.Parent.Parent.Data, $Test.Parent.Data, $Test.Data).where{ $PSItem }
+  foreach ($DataItem in $DataSources) {
+    if ($DataItem) {
+      if ($DataItem -is [IDictionary]) {
+        $DataItem.GetEnumerator().foreach{
+          $Data.$($PSItem.Name) = $PSItem.Value
+        }
+      } else {
+        #Save to the "_" key if it was an array input since that's what Pester uses for substitution
+        $Data._ = $DataItem
+      }
+    }
+  }
+  return $Data
 }
 
 function Expand-TestCaseName {
-	[CmdletBinding()]
-	param(
-		[Parameter(Mandatory, ValueFromPipeline)]
-		$Test
-	)
-	begin {
-		Test-IsPesterObject $Test
-	}
-	process {
-		[String]$Name = $Test.Name.ToString()
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    $Test
+  )
+  begin {
+    Test-IsPesterObject $Test
+  }
+  process {
+    [String]$Name = $Test.Name.ToString()
 
-		$Data = Merge-TestData $Test
+    $Data = Merge-TestData $Test
 
-		# Array value was stored as _ by Merge-TestData
-		$Data.GetEnumerator().ForEach{
-			$Name = $Name -replace ('<{0}>' -f $PSItem.Key), $PSItem.Value
-		}
+    # Array value was stored as _ by Merge-TestData
+    $Data.GetEnumerator().ForEach{
+      $Name = $Name -replace ('<{0}>' -f $PSItem.Key), $PSItem.Value
+    }
 
-		return $Name
-	}
-}
-
-function ConvertTo-LowercaseDriveLetter ([string]$String) {
-	if ($isWindows -or $PSEdition -eq 'Desktop') {
-		$result = $string.ToCharArray()
-		$result[0] = [Char]::ToLower( $result[0] )
-		return [System.String]::Join( '', $result )
-	}
+    return $Name
+  }
 }
 
 function New-TestItemId {
-	<#
+  <#
     .SYNOPSIS
     Create a string that uniquely identifies a test or test suite
     .NOTES
     Can be replaced with expandedpath if https://github.com/pester/Pester/issues/2005 is fixed
     #>
-	[CmdletBinding()]
-	param(
-		[Parameter(Mandatory, ValueFromPipeline)]
-		[ValidateScript( {
-				$null -ne ($_.PSTypeNames -match '(Pester\.)?(Block|Test)$')
-			})]$Test,
-		$TestIdDelimiter = '>>',
-		[Parameter(DontShow)][Switch]$AsString,
-		[Parameter(DontShow)][Switch]$AsHash
-	)
-	process {
-		if ($Test.Path -match $TestIdDelimiter) {
-			throw [NotSupportedException]"The delimiter $TestIdDelimiter is not supported in test names with this adapter. Please remove all pipes from test/context/describe names"
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [ValidateScript( {
+        $null -ne ($_.PSTypeNames -match '(Pester\.)?(Block|Test)$')
+      })]$Test,
+    $TestIdDelimiter = '>>',
+    [Parameter(DontShow)][Switch]$AsString,
+    [Parameter(DontShow)][Switch]$AsHash
+  )
+  process {
+
+    if ($Test.Path -match $TestIdDelimiter) {
+      throw [NotSupportedException]"The delimiter $TestIdDelimiter is not supported in test names with this adapter. Please remove all pipes from test/context/describe names"
+    }
+
+    $Data = Merge-TestData $Test
+
+    #Add a suffix of the testcase/foreach info that should uniquely identify the etst
+    #TODO: Maybe use a hash of the serialized object if it is not natively a string?
+    #TODO: Or maybe just hash the whole thing. The ID would be somewhat useless for troubleshooting
+    $DataItems = $Data.GetEnumerator() | Sort-Object Key | ForEach-Object {
+      [String]([String]$PSItem.Key + '=' + [String]$PSItem.Value)
+    }
+
+		# If this is a root container, just return the file path, since root containers can only be files (for now)
+		if ($Test -is [Pester.Block] -and $Test.IsRoot) {
+			return $Test.BlockContainer.Item.ToString().ToUpper()
 		}
 
-		$Data = Merge-TestData $Test
+    [String]$TestID = @(
+      # Javascript uses lowercase drive letters
+      $Test.ScriptBlock.File
+      # Can NOT Use expandedPath here, because when test runs it extrapolates
+      $Test.Path
+      $DataItems
+    ).Where{ $PSItem } -join '>>'
 
-		#Add a suffix of the testcase/foreach info that should uniquely identify the etst
-		#TODO: Maybe use a hash of the serialized object if it is not natively a string?
-		#TODO: Or maybe just hash the whole thing. The ID would be somewhat useless for troubleshooting
-		$DataItems = $Data.GetEnumerator() | Sort-Object Key | ForEach-Object {
-			[String]([String]$PSItem.Key + '=' + [String]$PSItem.Value)
-		}
+    if (-not $TestID) { throw 'A test ID was not generated. This is a bug.' }
 
-		$TestID = @(
-			# Javascript uses lowercase drive letters
-			ConvertTo-LowercaseDriveLetter($Test.ScriptBlock.File)
-			# Can NOT Use expandedPath here, because when test runs it extrapolates
-			$Test.Path
-			$DataItems
-		).Where{ $PSItem } -join '>>'
+    if ($AsHash) {
+      #Clever: https://www.reddit.com/r/PowerShell/comments/dr3taf/does_powershell_have_a_native_command_to_hash_a/
+      #TODO: This should probably be a helper function
+      Write-Debug "Non-Hashed Test ID for $($Test.ExpandedPath): $TestID"
+      return (Get-FileHash -InputStream (
+          [IO.MemoryStream]::new(
+            [Text.Encoding]::UTF8.GetBytes($TestID)
+          )
+        ) -Algorithm SHA256).hash
+    }
 
+    # -AsString is now the default, keeping for other existing references
 
-		if (-not $TestID) { throw 'A test ID was not generated. This is a bug.' }
+    # ToUpper is used to normalize windows paths to all uppercase
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+      $TestID = $TestID.ToUpper()
+    }
+    return $TestID
 
-		if ($AsHash) {
-			#Clever: https://www.reddit.com/r/PowerShell/comments/dr3taf/does_powershell_have_a_native_command_to_hash_a/
-			#TODO: This should probably be a helper function
-			Write-Debug "Non-Hashed Test ID for $($Test.ExpandedPath): $TestID"
-			return (Get-FileHash -InputStream (
-					[IO.MemoryStream]::new(
-						[Text.Encoding]::UTF8.GetBytes($TestID)
-					)
-				) -Algorithm SHA256).hash
-		}
-
-		# -AsString is now the default, keeping for other existing references
-		return $TestID
-
-	}
+  }
 }
 
 function Test-IsPesterObject($Test) {
-	#We don't use types here because they might not be loaded yet
-	$AllowedObjectTypes = [String[]]@(
-		'Test'
-		'Block'
-		'Pester.Test'
-		'Pester.Block'
-		'Deserialized.Pester.Test'
-		'Deserialized.Pester.Block'
-	)
-	$AllowedObjectTypes.foreach{
-		if ($PSItem -eq $Test.PSTypeNames[0]) {
-			$MatchesType = $true
-			return
-		}
-	}
-	if (-not $MatchesType) { throw 'Provided object is not a Pester Test or Pester Block' }
+  #We don't use types here because they might not be loaded yet
+  $AllowedObjectTypes = [String[]]@(
+    'Test'
+    'Block'
+    'Pester.Test'
+    'Pester.Block'
+    'Deserialized.Pester.Test'
+    'Deserialized.Pester.Block'
+  )
+  $AllowedObjectTypes.foreach{
+    if ($PSItem -eq $Test.PSTypeNames[0]) {
+      $MatchesType = $true
+      return
+    }
+  }
+  if (-not $MatchesType) { throw 'Provided object is not a Pester Test or Pester Block' }
 }
 
 function Get-DurationString($Test) {
-	if (-not ($Test.UserDuration -and $Test.FrameworkDuration)) { return }
-	$p = Get-Module Pester
-	& ($p) {
-		$Test = $args[0]
-		'({0}|{1})' -f (Get-HumanTime $Test.UserDuration), (Get-HumanTime $Test.FrameworkDuration)
-	} $Test
+  if (-not ($Test.UserDuration -and $Test.FrameworkDuration)) { return }
+  $p = Get-Module Pester
+  & ($p) {
+    $Test = $args[0]
+    '({0}|{1})' -f (Get-HumanTime $Test.UserDuration), (Get-HumanTime $Test.FrameworkDuration)
+  } $Test
 }
 
 function New-TestObject ($Test) {
-	Test-IsPesterObject $Test
+  Test-IsPesterObject $Test
 
-	#HACK: Block and Parent are equivalent so this simplifies further code
-	if ($Test -is [Pester.Test]) {
-		Add-Member -InputObject $Test -NotePropertyName 'Parent' -NotePropertyValue $Test.Block -Force
-	}
+  #HACK: Block and Parent are equivalent so this simplifies further code
+  if ($Test -is [Pester.Test]) {
+    Add-Member -InputObject $Test -NotePropertyName 'Parent' -NotePropertyValue $Test.Block -Force
+  }
 
-	#Common stuff first
-	$Parent = if ($Test.Parent -and -not $Test.Parent.IsRoot) {
-		#FIXME: Must be ID
-		New-TestItemId $Test.Parent
-	} elseif ($Test -is [Pester.Block]) {
-		$null
-	} else {
-		throw "Item $($Test.Name) is a test but doesn't have an ancestor. This is a bug."
-	}
+  #Common stuff first
+  [String]$Parent = if ($Test.Parent -and -not $Test.Parent.IsRoot) {
+    New-TestItemId $Test.Parent
+  } elseif ($Test.Parent.IsRoot -and $Test -is [Pester.Block]) {
+    #This is a Context or describe block that doesn't have a parent so don't make a parent ID
+    $null
+  } elseif ($Test.IsRoot -and $Test -is [Pester.Block] -and $Test.ErrorRecord -and $Test.Result -eq 'Failed') {
+    # This is probably a syntax error in a describe block
+    $null
+  } else {
+    throw "Item $($Test.Name) is a test but doesn't have an ancestor. This is a bug."
+  }
 
-	if ($Test.ErrorRecord) {
-		#TODO: Better handling once pester adds support
-		#Reference: https://github.com/pester/Pester/issues/1993
-		$Message = [string]$Test.ErrorRecord
-		if ([string]$Test.ErrorRecord -match 'Expected (?<Expected>.+?), but (got )?(?<actual>.+?)\.$') {
-			$Expected = $matches['Expected']
-			$Actual = $matches['Actual']
+  if ($Test.ErrorRecord) {
+		if ($Test -is [Pester.Block]) {
+			[String]$DiscoveryError = $Test.ErrorRecord
+		} else {
+			#TODO: Better handling once pester adds support
+			#Reference: https://github.com/pester/Pester/issues/1993
+			$Message = [string]$Test.ErrorRecord
+			if ([string]$Test.ErrorRecord -match 'Expected (?<Expected>.+?), but (got )?(?<actual>.+?)\.$') {
+				$Expected = $matches['Expected']
+				$Actual = $matches['Actual']
+			}
 		}
-	}
+  }
 
-	# TypeScript does not validate these data types, so numbers must be expressly stated so they don't get converted to strings
-	[PSCustomObject]@{
-		type           = $Test.ItemType
-		id             = New-TestItemId $Test
-		file           = ConvertTo-LowercaseDriveLetter($Test.ScriptBlock.File)
-		startLine      = [int]($Test.StartLine - 1) #Lines are zero-based in vscode
-		endLine        = [int]($Test.ScriptBlock.StartPosition.EndLine - 1) #Lines are zero-based in vscode
-		label          = Expand-TestCaseName $Test
-		result         = [ResultStatus]$(if ($null -eq $Test.Result) { 'NotRun' } else { $Test.Result })
-		duration       = $Test.UserDuration.TotalMilliseconds #I don't think anyone is doing sub-millisecond code performance testing in Powershell :)
-		durationDetail = Get-DurationString $Test
-		message        = $Message
-		expected       = $Expected
-		actual         = $Actual
-		targetFile     = $Test.ErrorRecord.TargetObject.File
-		targetLine     = [int]$Test.ErrorRecord.TargetObject.Line - 1
-		parent         = $Parent
-		tags           = $Test.Tag.Where{ $PSItem } -join ', '
-
-		#TODO: Severity. Failed = Error Skipped = Warning
-	}
+  # TypeScript does not validate these data types, so numbers must be expressly stated so they don't get converted to strings
+  [PSCustomObject]@{
+    type           = $Test.ItemType
+    id             = New-TestItemId $Test
+		error					 = $DiscoveryError
+    file           = $Test.ScriptBlock.File
+    startLine      = [int]($Test.StartLine - 1) #Lines are zero-based in vscode
+    endLine        = [int]($Test.ScriptBlock.StartPosition.EndLine - 1) #Lines are zero-based in vscode
+    label          = Expand-TestCaseName $Test
+    result         = [ResultStatus]$(if ($null -eq $Test.Result) { 'NotRun' } else { $Test.Result })
+    duration       = $Test.UserDuration.TotalMilliseconds #I don't think anyone is doing sub-millisecond code performance testing in Powershell :)
+    durationDetail = Get-DurationString $Test
+    message        = $Message
+    expected       = $Expected
+    actual         = $Actual
+    targetFile     = $Test.ErrorRecord.TargetObject.File
+    targetLine     = [int]$Test.ErrorRecord.TargetObject.Line - 1
+    parent         = $Parent
+    tags           = $Test.Tag.Where{ $PSItem } -join ', '
+    #TODO: Severity. Failed = Error Skipped = Warning
+  }
 }
 
 
 function Get-TestItemParents {
-	<#
+  <#
     .SYNOPSIS
     Returns any parents not already known, top-down first, so that a hierarchy can be created in a streaming manner
     #>
-	param (
-		#Test to fetch parents of. For maximum efficiency this should be done one test at a time and then stack processed
-		[Parameter(Mandatory, ValueFromPipeline)][Pester.Test[]]$Test,
-		[HashSet[Pester.Block]]$KnownParents = [HashSet[Pester.Block]]::new()
-	)
+  param (
+    #Test to fetch parents of. For maximum efficiency this should be done one test at a time and then stack processed
+    [Parameter(Mandatory, ValueFromPipeline)][Pester.Test[]]$Test,
+    [HashSet[Pester.Block]]$KnownParents = [HashSet[Pester.Block]]::new()
+  )
 
-	begin {
-		[Stack[Pester.Block]]$NewParents = [Stack[Pester.Block]]::new()
-	}
-	process {
-		# Output all parents that we don't know yet (distinct parents), in order from the top most
-		# to the child most.
-		foreach ($TestItem in $Test) {
-			$NewParents.Clear()
-			$parent = $TestItem.Block
+  begin {
+    [Stack[Pester.Block]]$NewParents = [Stack[Pester.Block]]::new()
+  }
+  process {
+    # Output all parents that we don't know yet (distinct parents), in order from the top most
+    # to the child most.
+    foreach ($TestItem in $Test) {
+      $NewParents.Clear()
+      $parent = $TestItem.Block
 
-			while ($null -ne $parent -and -not $parent.IsRoot) {
-				if (-not $KnownParents.Add($parent)) {
-					# We know this parent, so we must know all of its parents as well.
-					# We don't need to go further.
-					break
-				}
+      while ($null -ne $parent -and -not $parent.IsRoot) {
+        if (-not $KnownParents.Add($parent)) {
+          # We know this parent, so we must know all of its parents as well.
+          # We don't need to go further.
+          break
+        }
 
-				$NewParents.Push($parent)
-				$parent = $parent.Parent
-			}
+        $NewParents.Push($parent)
+        $parent = $parent.Parent
+      }
 
-			# Output the unknown parent objects from the top most, to the one closest to our test.
-			foreach ($p in $NewParents) { $p }
-		}
-	}
+      # Output the unknown parent objects from the top most, to the one closest to our test.
+      foreach ($p in $NewParents) { $p }
+    }
+  }
 }
 
-
 $MyPlugin = @{
-	Name                = 'TestPlugin'
-	Start               = {
-		$SCRIPT:__TestAdapterKnownParents = [HashSet[Pester.Block]]::new()
-		Write-Host -ForegroundColor Green "Connecting to pipe $pipename"
-		$SCRIPT:__TestAdapterNamedPipeClient = [IO.Pipes.NamedPipeClientStream]::new($PipeName)
-		$__TestAdapterNamedPipeClient.Connect(5000)
-		$SCRIPT:__TestAdapterNamedPipeWriter = [System.IO.StreamWriter]::new($__TestAdapterNamedPipeClient)
-	}
-	DiscoveryEnd        = {
-		param($Context)
-		if (-not $Discovery) { continue }
-		$discoveredTests = & (Get-Module Pester) { $Context.BlockContainers | View-Flat }
-		$discoveredTests.foreach{
-			[Pester.Block[]]$testSuites = Get-TestItemParents -Test $PSItem -KnownParents $SCRIPT:__TestAdapterKnownParents
-			$testSuites.foreach{
-				$testItem = New-TestObject $PSItem
-				[string]$jsonObject = ConvertTo-Json $testItem -Compress -Depth 1
-				$__TestAdapterNamedPipeWriter.WriteLine($jsonObject)
-			}
-			$testItem = New-TestObject $PSItem
-			[string]$jsonObject = ConvertTo-Json $testItem -Compress -Depth 1
-			$__TestAdapterNamedPipeWriter.WriteLine($jsonObject)
-		}
+  Name               = 'TestPlugin'
+  Start              = {
+    $SCRIPT:__TestAdapterKnownParents = [HashSet[Pester.Block]]::new()
+    Write-Host -ForegroundColor Green "Connecting to pipe $pipename"
+    $SCRIPT:__TestAdapterNamedPipeClient = [IO.Pipes.NamedPipeClientStream]::new($PipeName)
+    $__TestAdapterNamedPipeClient.Connect(5000)
+    $SCRIPT:__TestAdapterNamedPipeWriter = [System.IO.StreamWriter]::new($__TestAdapterNamedPipeClient)
+  }
+  DiscoveryEnd       = {
+    param($Context)
+    if (-not $Discovery) { continue }
+    $discoveredTests = & (Get-Module Pester) { $Context.BlockContainers | View-Flat }
+    $failedBlocks = $Context.BlockContainers | Where-Object -Property ErrorRecord
+    $discoveredTests += $failedBlocks
+    $discoveredTests.foreach{
+      if ($PSItem -is [Pester.Test]) {
+        [Pester.Block[]]$testSuites = Get-TestItemParents -Test $PSItem -KnownParents $SCRIPT:__TestAdapterKnownParents
+        $testSuites.foreach{
+          $testItem = New-TestObject $PSItem
+          [string]$jsonObject = ConvertTo-Json $testItem -Compress -Depth 1
+          $__TestAdapterNamedPipeWriter.WriteLine($jsonObject)
+        }
+      }
+
+      $testItem = New-TestObject $PSItem
+      [string]$jsonObject = ConvertTo-Json $testItem -Compress -Depth 1
+      $__TestAdapterNamedPipeWriter.WriteLine($jsonObject)
+    }
 	}
 
 	EachTestTeardownEnd = {

--- a/sample/Tests/Basic.Tests.ps1
+++ b/sample/Tests/Basic.Tests.ps1
@@ -1,80 +1,74 @@
-
-Context 'Test' -Tag 'ContextTag','ContextTag2' {
-    It 'test' -Tag 'ItTag' {
-        $true
-    }
-}
 Describe 'Basic' {
 
-    Context 'Succeeds' {
-        It 'True' {
-            $true
-        }
-        It 'False' { $false }
-        It 'ShouldBeTrue' { $true | Should -Be $true }
-    }
-    Context 'Fails' {
-        It 'Throws' { throw 'Kaboom' }
-        It 'ShouldThrow' { { $true } | Should -Throw }
-        It 'ShouldBeTrue' { $false | Should -Be $true }
-        It 'ShouldBeGreaterThan' { 1 | Should -BeGreaterThan 2 }
-        It 'ShouldBeTrueBecause' { $false | Should -BeTrue -Because 'True is True'}
-    }
-    It 'Describe-Level Succeeds' { $true | Should -Be $true }
-    It 'Describe-Level Fails' { $true | Should -Be $false }
+	Context 'Succeeds' {
+		It 'True' {
+			$true
+		}
+		It 'False' { $false }
+		It 'ShouldBeTrue' { $true | Should -Be $true }
+	}
+	Context 'Fails' {
+		It 'Throws' { throw 'Kaboom' }
+		It 'ShouldThrow' { { $true } | Should -Throw }
+		It 'ShouldBeTrue' { $false | Should -Be $true }
+		It 'ShouldBeGreaterThan' { 1 | Should -BeGreaterThan 2 }
+		It 'ShouldBeTrueBecause' { $false | Should -BeTrue -Because 'True is True' }
+	}
+	It 'Describe-Level Succeeds' { $true | Should -Be $true }
+	It 'Describe-Level Fails' { $true | Should -Be $false }
 }
 
 Describe 'TestCases' {
-    It 'TestCase Array <_>' {
-        $_ | Should -Not -BeNullOrEmpty
-    } -TestCases @(
-        1
-        2
-        'red'
-        'blue'
-    )
-    It 'TestCase HashTable <Name>' {
-        $_ | Should -Not -BeNullOrEmpty
-    } -TestCases @(
-        @{Name = 1 }
-        @{Name = 2 }
-        @{Name = 'red' }
-        @{Name = 'blue' }
-    )
+	It 'TestCase Array <_>' {
+		$_ | Should -Not -BeNullOrEmpty
+	} -TestCases @(
+		1
+		2
+		'red'
+		'blue'
+	)
+	It 'TestCase HashTable <Name>' {
+		$_ | Should -Not -BeNullOrEmpty
+	} -TestCases @(
+		@{Name = 1 }
+		@{Name = 2 }
+		@{Name = 'red' }
+		@{Name = 'blue' }
+	)
 }
 
 Describe 'Describe Nested Foreach <name> <symbol>' -ForEach @(
-    @{ Name = 'cactus'; Symbol = '🌵'; Kind = 'Plant' }
-    @{ Name = 'giraffe'; Symbol = '🦒'; Kind = 'Animal' }
+	@{ Name = 'cactus'; Symbol = '🌵'; Kind = 'Plant' }
+	@{ Name = 'giraffe'; Symbol = '🦒'; Kind = 'Animal' }
 ) {
-    It 'Returns <symbol>' { $true }
+	It 'Returns <symbol>' { $true }
 
-    It 'Has kind <kind>' { $true }
+	It 'Has kind <kind>' { $true }
 
-    It 'Nested Hashtable TestCase <kind> <name>' { $true } -TestCases @{
-        Name = 'test'
-    }
-    It 'Nested Array TestCase <kind> <_>' { $true } -TestCases @(
-        'Test'
-    )
-    It 'Nested Multiple Hashtable TestCase <kind> <name> <symbol>' { $true } -TestCases @(
-        @{
-            Name = 'Pester1'
-        }
-        @{
-            Name = 'Pester2'
-        }
-    )
+	It 'Nested Hashtable TestCase <kind> <name>' { $true } -TestCases @{
+		Name = 'test'
+	}
+	It 'Nested Array TestCase <kind> <_>' { $true } -TestCases @(
+		'Test'
+	)
+	It 'Nested Multiple Hashtable TestCase <kind> <name> <symbol>' { $true } -TestCases @(
+		@{
+			Name = 'Pester1'
+		}
+		@{
+			Name = 'Pester2'
+		}
+	)
 
-    Context 'Context Nested Foreach <name> <ContextValue>' -Foreach @(
-        @{ ContextValue = 'Test1' }
-        @{ ContextValue = 'Test2' }
-    ) {
-        It 'Describe Context Nested Array <name> <contextvalue> <_>' -TestCases @(
-            'Test1'
-            'Test2'
-        ) {$true}
-    }
+	Context 'Context Nested Foreach <name> <ContextValue>' -ForEach @(
+		@{ ContextValue = 'Test1' }
+		@{ ContextValue = 'Test2' }
+	) {
+		It 'Describe Context Nested Array <name> <contextvalue> <_>' -TestCases @(
+			'Test1'
+			'Test2'
+		) { $true }
+	}
 }
 
 # Edge cases that may occur during editing
@@ -83,9 +77,14 @@ Describe 'Empty Describe' {}
 Describe 'Duplicate Describe' {}
 Describe 'Duplicate Describe' {}
 Describe 'Duplicate DescribeWithContext' {
-    Context 'DupeContext' {
-        It 'DupeContext' { $true }
-    }
+	Context 'DupeContext' {
+		It 'DupeContext' { $true }
+	}
+}
+Context 'RootLevelContextWithTags' -Tag 'ContextTag', 'ContextTag2' {
+	It 'ItTestWithTags' -Tag 'ItTag' {
+		$true
+	}
 }
 # Describe 'Duplicate DescribeWithContext' {
 #     Context 'DupeContext' {

--- a/sample/Tests/ContextSyntaxError.Tests.ps1
+++ b/sample/Tests/ContextSyntaxError.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'test' {
+	Context 'ok' {
+		$1 ----or !== $2
+	}
+}

--- a/sample/Tests/DescribeSyntaxError.Tests.ps1
+++ b/sample/Tests/DescribeSyntaxError.Tests.ps1
@@ -1,0 +1,1 @@
+Describe {

--- a/sample/Tests/DescribeSyntaxError.Tests.ps1
+++ b/sample/Tests/DescribeSyntaxError.Tests.ps1
@@ -1,1 +1,1 @@
-Describe {
+Describe 'test' {

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -4,6 +4,7 @@ import {
 	Extension,
 	ExtensionContext,
 	Location,
+	MarkdownString,
 	Position,
 	Range,
 	RelativePattern,
@@ -113,10 +114,23 @@ export class PesterTestController implements Disposable {
 		const testItemDiscoveryHandler = (t: unknown) => {
 			// TODO: This should be done before onDidReceiveObject maybe as a handler callback?
 			const testDef = t as TestDefinition
+
+			// If there was a syntax error, set the error and short circuit the rest
+			if (testDef.error !== undefined) {
+				const existingTest = this.testController.items.get(testDef.id)
+				if (existingTest) {
+					existingTest.error = new MarkdownString(
+						`**$(error)** ${testDef.error}`,
+						true
+					)
+					return
+				}
+			}
+
 			const parent =
 				testItemLookup.get(testDef.parent) ??
-				this.testController.items.get(testDef.file)
-			if (parent === undefined) {
+				this.testController.items.get(testDef.id)
+			if (parent === undefined && testDef.error === undefined) {
 				log.fatal(
 					`Test Item ${testDef.label} does not have a parent. This is a bug and should not happen`
 				)
@@ -131,9 +145,15 @@ export class PesterTestController implements Disposable {
 			)
 			newTestItem.range = new Range(testDef.startLine, 0, testDef.endLine, 0)
 			newTestItem.description = testDef.tags ? testDef.tags : undefined
+			if (testDef.error !== undefined) {
+				newTestItem.error = testDef.error
+			}
+
 			TestData.set(newTestItem, testDef)
 			testItemLookup.set(newTestItem.id, newTestItem)
-			parent.children.add(newTestItem)
+			if (parent !== undefined) {
+				parent.children.add(newTestItem)
+			}
 		}
 
 		if (

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -120,7 +120,7 @@ export class PesterTestController implements Disposable {
 				const existingTest = this.testController.items.get(testDef.id)
 				if (existingTest) {
 					existingTest.error = new MarkdownString(
-						`**$(error)** ${testDef.error}`,
+						`$(error) ${testDef.error}`,
 						true
 					)
 					return

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -129,7 +129,7 @@ export class PesterTestController implements Disposable {
 
 			const parent =
 				testItemLookup.get(testDef.parent) ??
-				this.testController.items.get(testDef.id)
+				this.testController.items.get(testDef.parent)
 			if (parent === undefined && testDef.error === undefined) {
 				log.fatal(
 					`Test Item ${testDef.label} does not have a parent. This is a bug and should not happen`
@@ -152,6 +152,7 @@ export class PesterTestController implements Disposable {
 			TestData.set(newTestItem, testDef)
 			testItemLookup.set(newTestItem.id, newTestItem)
 			if (parent !== undefined) {
+				log.debug(`Adding ${newTestItem.label} to ${parent.label}`)
 				parent.children.add(newTestItem)
 			}
 		}
@@ -165,7 +166,7 @@ export class PesterTestController implements Disposable {
 			testItem.busy = true
 
 			// Run Pester and get tests
-			log.info('Adding to Discovery Queue: ', testItem.id)
+			log.debug('Adding to Discovery Queue: ', testItem.id)
 			this.resolveQueue.push(testItem)
 			// For discovery we don't care about the terminal output, thats why no assignment to var here
 			await this.startTestDiscovery(testItemDiscoveryHandler)
@@ -297,7 +298,7 @@ export class PesterTestController implements Disposable {
 						testDataItem instanceof TestFile &&
 						!testDataItem.testsDiscovered
 					) {
-						log.info(
+						log.debug(
 							`Run invoked on undiscovered testFile ${testItem.label}, discovery will be run first`
 						)
 						return [this.resolveHandler(testItem)]

--- a/src/pesterTestTree.ts
+++ b/src/pesterTestTree.ts
@@ -58,13 +58,15 @@ export class TestFile {
 
 	/** Creates a managed TestItem entry in the controller if it doesn't exist, or returns the existing object if it does already exist */
 	static getOrCreate(controller: TestController, uri: Uri): TestItem {
-		const uriFsPath = uri.fsPath
+		// Normalize paths to uppercase on windows due to formatting differences between Javascript and PowerShell
+		const uriFsPath =
+			process.platform === 'win32' ? uri.fsPath.toUpperCase() : uri.fsPath
 		const existing = controller.items.get(uri.toString())
 		if (existing) {
 			return existing
 		}
 		const fileTestItem = controller.createTestItem(
-			uri.fsPath,
+			uriFsPath,
 			uri.path.split('/').pop()!,
 			uri
 		)


### PR DESCRIPTION
Fixes #38 and #25