### PR TITLE
✨ Disable Pester CodeLens Adapter Prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "Automatically runs Pester test files upon changes being detected on save. Uncheck this box to disable this behavior."
+				},
+				"pester.suppressCodeLensNotice": {
+					"type": "boolean",
+					"markdownDescription": "It is recommended to disable the PowerShell Pester CodeLens when using this extension. Check this box to suppress this dialog. Choosing 'No' in the dialog box will also enable this at a user level"
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,9 @@
-import { ExtensionContext } from 'vscode'
+import { ExtensionContext, window, workspace } from 'vscode'
 import { PesterTestController } from './pesterTestController'
-import { getPowerShellExtension } from './powershellExtensionClient'
+import {
+	getPowerShellExtension,
+	PowerShellExtensionClient
+} from './powershellExtensionClient'
 export async function activate(context: ExtensionContext) {
 	// PowerShell extension is a prerequisite, but we allow either preview or normal, which is why we do this instead of
 	// leverage package.json dependencies
@@ -8,10 +11,53 @@ export async function activate(context: ExtensionContext) {
 
 	// Short circuit this activate call if we didn't find a PowerShell Extension. Another activate will be triggered once
 	// the powershell extension is available
-
 	if (!powershellExtension) {
 		return
 	}
+
+	// Disable PowerShell codelens setting if present
+	const psExtensionCodeLensSetting =
+		PowerShellExtensionClient.GetPesterSettings().codeLens
+	const suppressCodeLensNotice = workspace
+		.getConfiguration('pester')
+		.get<boolean>('suppressCodeLensNotice')
+
+	if (psExtensionCodeLensSetting && !suppressCodeLensNotice) {
+		window
+			.showInformationMessage(
+				'The Pester Tests extension recommends disabling the built-in PowerShell extension CodeLens. Would you like to do this?',
+				'Yes',
+				'Workspace Only',
+				'No',
+				'Dont Ask Again'
+			)
+			.then(response => {
+				switch (response) {
+					case 'No': {
+						return
+					}
+					case 'Yes': {
+						workspace
+							.getConfiguration('powershell.pester')
+							.update('codeLens', false, true)
+						break
+					}
+					case 'This Workspace Only': {
+						workspace
+							.getConfiguration('powershell.pester')
+							.update('codeLens', false, false)
+						break
+					}
+					case 'Dont Ask Again': {
+						workspace
+							.getConfiguration('pester')
+							.update('suppressCodeLensNotice', true, true)
+						break
+					}
+				}
+			})
+	}
+
 	context.subscriptions.push(
 		new PesterTestController(powershellExtension, context)
 	)


### PR DESCRIPTION
Adds a prompt to disable the Pester Codelens adapter when the Pester extension is in use.