### PR TITLE
Add configuration option for custom Pester module path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,11 @@ Answer _yes_  on all questions.
 Build using:
 
 ```bash
-npm run build
+npm run build vX.X.X
 ```
+
+Replace X.X.X with the version number of the extension. Can be any version number for testing to install and
+use the extension in VS Code.
 
 ## Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@ submit a pull request, all without ever having to clone the repository locally.
 
 TODO: "Peek with VSCode Remote Repositories" button
 
+# Running Tests
+This project uses the Jest test framework with the esbuild-jest plugin to quickly compile the typescript for testing.
+
 # Development
 
 The extension is broken into the following abstraction layers:
@@ -17,32 +20,3 @@ The extension is broken into the following abstraction layers:
    the Pester hierarchy (File/Describe/Context/It) though additional hierarchies (Group by Tag/Function/etc) are planned
 1. **PesterTestRunner** - Contains methods for running pester tests, used by Pester Test Controller
 1. **PowerShellRunner** - Contains methods for running powershell scripts, used by PesterTestRunner
-
-## Resolve dependencies
-
-Resolve dependencies with:
-
-```bash
-npm run install
-```
-
-Answer _yes_  on all questions.
-
-## Build project
-
-Build using:
-
-```bash
-npm run build vX.X.X
-```
-
-Replace X.X.X with the version number of the extension. Can be any version number for testing to install and
-use the extension in VS Code.
-
-## Running Tests
-
-This project uses the Jest test framework with the esbuild-jest plugin to quickly compile the typescript for testing.
-
-```bash
-npm run tests
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,6 @@ submit a pull request, all without ever having to clone the repository locally.
 
 TODO: "Peek with VSCode Remote Repositories" button
 
-# Running Tests
-This project uses the Jest test framework with the esbuild-jest plugin to quickly compile the typescript for testing.
-
 # Development
 
 The extension is broken into the following abstraction layers:
@@ -20,3 +17,29 @@ The extension is broken into the following abstraction layers:
    the Pester hierarchy (File/Describe/Context/It) though additional hierarchies (Group by Tag/Function/etc) are planned
 1. **PesterTestRunner** - Contains methods for running pester tests, used by Pester Test Controller
 1. **PowerShellRunner** - Contains methods for running powershell scripts, used by PesterTestRunner
+
+## Resolve dependencies
+
+Resolve dependencies with:
+
+```bash
+npm run install
+```
+
+Answer _yes_  on all questions.
+
+## Build project
+
+Build using:
+
+```bash
+npm run build
+```
+
+## Running Tests
+
+This project uses the Jest test framework with the esbuild-jest plugin to quickly compile the typescript for testing.
+
+```bash
+npm run tests
+```

--- a/Scripts/PesterInterface.ps1
+++ b/Scripts/PesterInterface.ps1
@@ -17,7 +17,9 @@ param(
 	#The verbosity to pass to the system
 	[String]$Verbosity,
 	#If specified, the shim will write to a temporary file at Pipename path and this script will output what would have been written to the stream. Useful for testing.
-	[Switch]$DryRun
+	[Switch]$DryRun,
+	#An optional custom path to the Pester module.
+	[String]$PesterModulePath
 )
 
 $VerbosePreference = 'SilentlyContinue'
@@ -456,6 +458,19 @@ Warning: This only works once, not designed for repeated plugin injection
 
 #Main Function
 function Invoke-Main {
+    <#
+        If no custom module path is provided the Pester module in $env:PSModulePath will be used.
+        It will be imported automatically when New-PesterConfiguration is used below, if it is
+        not already in the session.
+    #>
+    if ($PesterModulePath -and -not (Get-Module -Name 'Pester')) {
+        if (-not (Test-Path -Path $PesterModulePath)) {
+            throw "Pester module not found at $PesterModulePath"
+        }
+
+        Import-Module -Name $PesterModulePath
+    }
+
 	# These should be unique which is why we use a hashset
 	$paths = [HashSet[string]]::new()
 	$lines = [HashSet[string]]::new()

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 				},
 				"pester.pesterModulePath": {
 					"type": "string",
-					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path under the current project is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by `$env:PSModulePath`. **NOTE:** This is not currently supported for debugging tests."
+					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path under the current project is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by `$env:PSModulePath`."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
 				"pester.runTestsInNewProcess": {
 					"type": "boolean",
 					"markdownDescription": "This will cause all Pester Test invocations to occur each time in a new process, rather than reuse a runspace. This is useful if you are testing Powershell Classes or Assemblies that cannot be unloaded or reloaded, but comes at a significant performance cost. This currently has no effect on debugging tests."
+				},
+				"pester.pesterModulePath": {
+					"type": "string",
+					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by $env:PSModulePath. **NOTE:** This is not currently supported for debugging tests."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 				},
 				"pester.pesterModulePath": {
 					"type": "string",
-					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by $env:PSModulePath. **NOTE:** This is not currently supported for debugging tests."
+					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path under the current project is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by $env:PSModulePath. **NOTE:** This is not currently supported for debugging tests."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 				},
 				"pester.pesterModulePath": {
 					"type": "string",
-					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path under the current project is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by $env:PSModulePath. **NOTE:** This is not currently supported for debugging tests."
+					"markdownDescription": "This allows to specify a custom path to the Pester module. A relative path under the current project is allowed. If this is not set then Pester module is expected to be found in one of the paths specified by `$env:PSModulePath`. **NOTE:** This is not currently supported for debugging tests."
 				}
 			}
 		},

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -473,6 +473,15 @@ export class PesterTestController implements Disposable {
 			await this.powerShellExtensionClient.GetVersionDetails()
 		}
 
+        const pesterModulePath = workspace
+            .getConfiguration('pester')
+            .get<string>('pesterModulePath')
+
+        if (pesterModulePath) {
+            scriptArgs.push('-PesterModulePath')
+            scriptArgs.push(`"${pesterModulePath}"`)
+        }
+
 		// If PSIC is running, we will connect the PowershellExtensionClient to be able to fetch info about it
 		const psicLoaded = window.terminals.find(
 			t => t.name === 'PowerShell Integrated Console'

--- a/src/pesterTestController.ts
+++ b/src/pesterTestController.ts
@@ -477,10 +477,19 @@ export class PesterTestController implements Disposable {
             .getConfiguration('pester')
             .get<string>('pesterModulePath')
 
-        if (pesterModulePath) {
+        if (pesterModulePath && workspace.workspaceFolders) {
+            // TODO: Hard-coded to first workspace folder for now,
+            //       but should look through all workspace folders
+            //       for a working path to Pester module
+            const workspaceFolder = workspace.workspaceFolders[0]
+            const workspaceFolderPath = workspaceFolder.uri.fsPath
+            const pesterModulePathInWorkspace = join(workspaceFolderPath, pesterModulePath)
+
             scriptArgs.push('-PesterModulePath')
-            scriptArgs.push(`"${pesterModulePath}"`)
+            // Quotes are required if the test path has spaces
+            scriptArgs.push(`'${pesterModulePathInWorkspace}'`)
         }
+
 
 		// If PSIC is running, we will connect the PowershellExtensionClient to be able to fetch info about it
 		const psicLoaded = window.terminals.find(


### PR DESCRIPTION
@JustinGrote this is my attempt to fix issue #108. Please give pointers if I missed something, I followed how `runTestsInNewProcess` was done to get an idea where to change stuff. 🙂 

- Add new configuration property `pesterModulePath`
- Update CONTRIBUTING.md to help contributors.

Fixes #108 
Closes #95 
