### PR TITLE
🎉 Enable cancellation for test runs and refresh runs

### DIFF
--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -329,7 +329,7 @@ export class PowerShell {
 				'{"__PSINVOCATIONID": "CANCELLED", "finished": true}'
 			)
 		}
-		this.reset()
+		return this.reset()
 	}
 
 	/** Kill any existing invocations and reset the state */


### PR DESCRIPTION
Closes #149
Adds the ability to cancel test runs, should be cancellable at any point during a run. This currently is a "hard" cancel, it kills the PowerShell process and restarts it.