### PR TITLE
🎉 Add VSCode Continuous Run Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ This extension provides the ability to run [Pester](https://pester.dev/) tests u
 
 ### Highlights
 
-🔍 **Pester Test Browser**  
-🐞 **Debugging Support**  
-👩‍💻 **Native PowerShell Extension Integration**  
-👨‍👧‍👦 **Expands Test Cases**  
+🔍 **Pester Test Browser**
+🐞 **Debugging Support**
+👩‍💻 **Native PowerShell Extension Integration**
+👨‍👧‍👦 **Expands Test Cases**
+
+
 
 ### Extension Prerequisites
 
@@ -50,3 +52,7 @@ This extension will use the PowerShell Extension Pester verbosity settings for t
 ### Troubleshooting
 
 The Pester `Output` pane maintains a log of the activities that occur with the Pester extension. You can use `Set Log Level` in the command palette to increase the log level to debug or trace to get more information about what is going on. Include this information when submitting an issue along with reproduction steps.
+
+### Notes
+
+- For test history purposes, a test is uniquely identified by its full path, e.g. Describe/Context/It. If you rename a test or move a test to another context/describe, it will be treated as a new test and test history will be reset

--- a/Scripts/PesterTestPlugin.psm1
+++ b/Scripts/PesterTestPlugin.psm1
@@ -322,6 +322,7 @@ function New-TestObject ($Test) {
 		targetLine     = [int]$Test.ErrorRecord.TargetObject.Line - 1
 		parent         = $Parent
 		tags           = $Test.Tag.Where{ $PSItem }
+		scriptBlock    = if ($Test -is [Pester.Test]) { $Test.Block.ScriptBlock.ToString().Trim() }
 		#TODO: Severity. Failed = Error Skipped = Warning
 	}
 }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
 					"type": "string",
 					"markdownDescription": "Specifies the working directory of the dedicated Pester Instance. While $PSScriptRoot is recommended when using relative paths in Pester Tests, the runner will also default to the path of the current first workspace folder. Specify this if you want a different working directory."
 				},
-
-				// Deprecated Settings
 				"pester.autoRunOnSave": {
 					"type": "boolean",
 					"default": false,
@@ -63,31 +61,32 @@
 		"commands": [
 			{
 				"command": "pester.stopPowerShell",
-				"title": "Pester: Stop PowerShell background process",
+				"title": "Pester: Stop PowerShell background process DEPRECATED: Use Test UI refresh button instead",
+				"category": "PowerShell",
+				"enablement": "false"
+			},
+			{
+				"command": "pester.toggleAutoRunOnSave",
+				"title": "Pester: Toggle Auto Run on Save DEPRECATED: Use Test UI continuous run button instead",
+				"enablement": "false",
 				"category": "PowerShell"
 			}
-			// DEPRECATED: This is now handled by the VSCode native continuous interface
-			// {
-			// 	"command": "pester.toggleAutoRunOnSave",
-			// 	"title": "Pester: Toggle Auto Run on Save",
-			// 	"enablement": "",
-			// 	"category": "PowerShell"
-			// },
 		],
 		"menus": {
-			// DEPRECATED: This is now handled by the VSCode native continuous interface
-			// "testing/item/context": [
-			// 	{
-			// 		"command": "pester.toggleAutoRunOnSave",
-			// 		"group": "pester"
-			// 	}
-			// ],
-			// "testing/item/gutter": [
-			// 	{
-			// 		"command": "pester.toggleAutoRunOnSave",
-			// 		"group": "pester"
-			// 	}
-			// ]
+			"testing/item/context": [
+				{
+					"command": "pester.toggleAutoRunOnSave",
+					"group": "pester",
+					"when": "false"
+				}
+			],
+			"testing/item/gutter": [
+				{
+					"command": "pester.toggleAutoRunOnSave",
+					"group": "pester",
+					"when": "false"
+				}
+			]
 		}
 	},
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -29,15 +29,10 @@
 					"type": "boolean",
 					"markdownDescription": "If a skipped test is inconclusive or `Set-ItResult` had the `-Because` parameter specified, those are surfaced as test errors for easy viewing. Enable this setting if you prefer these to be displayed simply as skipped. **NOTE:** If you do this then you cannot see any BECAUSE messages without looking directly at the Pester output."
 				},
-				"pester.autoRunOnSave": {
-					"type": "boolean",
-					"default": true,
-					"markdownDescription": "Automatically runs Pester test files upon changes being detected on save. Uncheck this box to disable this behavior."
-				},
 				"pester.autoDebugOnSave": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "When enabled, will automatically start a debug run on a Pester file via the Powershell Integrated Console whenever it changes. This has no effect if `autoRunOnSave` is disabled."
+					"markdownDescription": "When enabled, continuous run tests will be debugged when changed in the PowerShell extension."
 				},
 				"pester.suppressCodeLensNotice": {
 					"type": "boolean",
@@ -54,34 +49,45 @@
 				"pester.workingDirectory": {
 					"type": "string",
 					"markdownDescription": "Specifies the working directory of the dedicated Pester Instance. While $PSScriptRoot is recommended when using relative paths in Pester Tests, the runner will also default to the path of the current first workspace folder. Specify this if you want a different working directory."
+				},
+
+				// Deprecated Settings
+				"pester.autoRunOnSave": {
+					"type": "boolean",
+					"default": false,
+					"deprecationMessage": "DEPRECATED: This is now handled by the VSCode native continuous run interface in the test handler.",
+					"markdownDescription": "Automatically runs Pester test files upon changes being detected on save. Uncheck this box to disable this behavior."
 				}
 			}
 		},
 		"commands": [
 			{
-				"command": "pester.toggleAutoRunOnSave",
-				"title": "Pester: Toggle Auto Run on Save",
-				"category": "PowerShell"
-			},
-			{
 				"command": "pester.stopPowerShell",
 				"title": "Pester: Stop PowerShell background process",
 				"category": "PowerShell"
 			}
+			// DEPRECATED: This is now handled by the VSCode native continuous interface
+			// {
+			// 	"command": "pester.toggleAutoRunOnSave",
+			// 	"title": "Pester: Toggle Auto Run on Save",
+			// 	"enablement": "",
+			// 	"category": "PowerShell"
+			// },
 		],
 		"menus": {
-			"testing/item/context": [
-				{
-					"command": "pester.toggleAutoRunOnSave",
-					"group": "pester"
-				}
-			],
-			"testing/item/gutter": [
-				{
-					"command": "pester.toggleAutoRunOnSave",
-					"group": "pester"
-				}
-			]
+			// DEPRECATED: This is now handled by the VSCode native continuous interface
+			// "testing/item/context": [
+			// 	{
+			// 		"command": "pester.toggleAutoRunOnSave",
+			// 		"group": "pester"
+			// 	}
+			// ],
+			// "testing/item/gutter": [
+			// 	{
+			// 		"command": "pester.toggleAutoRunOnSave",
+			// 		"group": "pester"
+			// 	}
+			// ]
 		}
 	},
 	"keywords": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,5 @@
 import { type ExtensionContext, window, workspace, commands } from 'vscode'
 
-import {
-	autoRunStatusBarItem,
-	autoRunStatusBarVisibleEvent,
-	toggleAutoRunOnSaveCommand,
-	updateAutoRunStatusBarOnConfigChange
-} from './features/toggleAutoRunOnSaveCommand'
 import { PesterTestController } from './pesterTestController'
 import {
 	getPowerShellExtension,
@@ -68,10 +62,6 @@ export async function activate(context: ExtensionContext) {
 
 	context.subscriptions.push(
 		controller,
-		toggleAutoRunOnSaveCommand,
 		stopPowerShellCommand,
-		autoRunStatusBarItem,
-		autoRunStatusBarVisibleEvent,
-		updateAutoRunStatusBarOnConfigChange
 	)
 }

--- a/src/pesterTestTree.ts
+++ b/src/pesterTestTree.ts
@@ -1,6 +1,6 @@
 /** Represents a test result returned from pester, serialized into JSON */
 
-import { TestController, TestItem, Uri } from 'vscode'
+import { Range, TestController, TestItem, Uri } from 'vscode'
 import log from './log'
 
 /** Represents all types that are allowed to be present in a test tree. This can be a single type or a combination of
@@ -93,6 +93,7 @@ export interface TestDefinition extends TestItemOptions {
 	description?: string
 	error?: string
 	tags?: string[]
+	scriptBlock?: string
 }
 
 /** The type used to represent a test run from the Pester runner, with additional status data */
@@ -107,4 +108,9 @@ export interface TestResult extends TestItemOptions {
 	targetFile: string
 	targetLine: number
 	description?: string
+}
+
+/** Given a testdefinition, fetch the vscode range */
+export function getRange(testDef: TestDefinition): Range {
+	return new Range(testDef.startLine, 0, testDef.endLine, 0)
 }

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -81,7 +81,7 @@ export class PSOutputUnified implements IPSOutput {
 export function createJsonParseTransform() {
 	return new Transform({
 		objectMode: true,
-		transform(chunk: string, encoding: string, next) {
+		transform(chunk: string, _encoding: string, next) {
 			const jsonResult = jsonParseSafe(chunk)
 			// Check if jsonResult is the non exported type OutputError
 			if ('error' in jsonResult) {
@@ -106,7 +106,7 @@ function createWatchForScriptFinishedMessageTransform(streamToEnd: Writable) {
 		objectMode: true,
 		// TODO: Strong type this
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		transform(chunk: any, encoding: string, next) {
+		transform(chunk: any, _encoding: string, next) {
 			// If special message from PowerShell Invocation Script
 			// TODO: Handle this as a class?
 			if (chunk.__PSINVOCATIONID && chunk.finished === true) {

--- a/src/testItemUtils.ts
+++ b/src/testItemUtils.ts
@@ -78,3 +78,4 @@ export function getParents(TestItem: TestItem) {
 export function isTestItemOptions(testItem: TestTree): testItem is TestDefinition {
 	return 'type' in testItem
 }
+


### PR DESCRIPTION
Resolves #137
- Add scriptblock to passed information for comparing changed tests
- Add changed test handling
- Wire up to coverage handler and start test run if changed tests detected