### PR TITLE
✨Enable OnStartupFinished activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
 		"Testing"
 	],
 	"activationEvents": [
-		"workspaceContains:**/*.[tT]ests.[pP][sS]1"
+		"workspaceContains:**/*.[tT]ests.[pP][sS]1",
+		"onStartupFinished"
 	],
 	"main": "./dist/extension.js",
 	"devDependencies": {


### PR DESCRIPTION
Adds a lazy load to pester in addition to the file type watcher. This will allow for:
1. Opening a empty environment and *then* creating a .tests.ps1 file and still be able to run it.
2. Allow for custom test discovery globs

Fixes #122