### PR TITLE
fix encoding errors when paths contain non-ascii characters #225

### DIFF
--- a/Scripts/PesterInterface.ps1
+++ b/Scripts/PesterInterface.ps1
@@ -24,6 +24,7 @@ param(
 	#Specify the path to a PesterConfiguration.psd1 file. The script will also look for a PesterConfiguration.psd1 in the current working directory.
 	[String]$ConfigurationPath
 )
+[Console]::OutputEncoding = [Text.Encoding]::UTF8
 
 try {
     $modulePath = if ($CustomModulePath) { Resolve-Path $CustomModulePath -ErrorAction Stop } else { 'Pester' }


### PR DESCRIPTION
The error was writing json filepaths like `foo.🐒` as `foo.≡ƒÉÆ` causing the missing path errors. 

Making this explicit means `PesterInterface.ps1` will write json paths using `utf8` even when ran from `pwsh -NoProfile`

<!--
Explicitly setting `utf8` ensures even `-NoProfile` runs of `PesterInterface.ps1` is using utf8 encoding for json filepaths
-->
```ps1
$Paths = @{
    PestInterface       = Join-Path $Env:UserProfile '.vscode\extensions\pspester.pester-test-2023.7.8\Scripts\PesterInterface.ps1'
    ToDiscover          = 'g:\temp\2025-11\example.🐒\example.tests.ps1'
}

& $Paths.PestInterface -Discovery $Paths.ToDiscover
```

### To reproduce the error

You should start a new terminal. Running `pwsh -Nop` alone is not sufficient. ( ie: it doesn't always reproduce after encoding is set once )
