### PR TITLE
Update broken badges in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Latest](https://img.shields.io/visual-studio-marketplace/v/pspester.pester-test?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/pspester.pester-test?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
 [![vsix](https://img.shields.io/github/v/release/pester/vscode-adapter?label=vsix&sort=semver&style=flat-square)](https://github.com/pester/vscode-adapter/releases)
-[![Build](https://img.shields.io/github/workflow/status/pester/vscode-adapter/ci.yml?style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/ci.yml)
-[![Analysis](https://img.shields.io/github/workflow/status/pester/vscode-adapter/codeql-analysis.yml/main?label=codeQL&style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/codeql-analysis.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/pester/vscode-adapter/ci.yml?branch=main&style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/ci.yml)
+[![Analysis](https://img.shields.io/github/actions/workflow/status/pester/vscode-adapter/codeql-analysis.yml?branch=main&style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/codeql-analysis.yml)
 
 [![License: MIT](https://img.shields.io/npm/l/tslog?logo=tslog&style=flat-square)](https://tldrlegal.com/license/mit-license)
 [![GitHub stars](https://img.shields.io/github/stars/pester/vscode-adapter?style=social)](https://github.com/pester/vscode-adapter)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Pester Test Adapter for Visual Studio Code](images/social-preview.png)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
-[![Latest](https://img.shields.io/visual-studio-marketplace/v/pspester.pester-test?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/pspester.pester-test?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
+[![Latest](https://vsmarketplacebadges.dev/version-short/pspester.pester-test.svg)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
+[![Installs](https://vsmarketplacebadges.dev/installs-short/pspester.pester-test.svg)](https://marketplace.visualstudio.com/items?itemName=pspester.pester-test)
 [![vsix](https://img.shields.io/github/v/release/pester/vscode-adapter?label=vsix&sort=semver&style=flat-square)](https://github.com/pester/vscode-adapter/releases)
 [![Build](https://img.shields.io/github/actions/workflow/status/pester/vscode-adapter/ci.yml?branch=main&style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/ci.yml)
 [![Analysis](https://img.shields.io/github/actions/workflow/status/pester/vscode-adapter/codeql-analysis.yml?branch=main&style=flat-square)](https://github.com/pester/vscode-adapter/actions/workflows/codeql-analysis.yml)


### PR DESCRIPTION
- Replaced VS Marketplace version + install badges. shields.io retired theirs, but vsmarketplacebadges.dev works
- Updated broken Github Actions badges per https://github.com/badges/shields/issues/8671 . CI-badge limited to main branch to avoid build failures for random dependabot runs.

Before:
<img width="756" height="100" alt="image" src="https://github.com/user-attachments/assets/18fb279b-8083-451e-b81d-0c2b75b3c993" />

After:
<img width="585" height="76" alt="image" src="https://github.com/user-attachments/assets/21773b20-0b68-4681-94f7-93ed6635d724" />